### PR TITLE
Fix edge case where oldest series always has length 1 and add cache management tools

### DIFF
--- a/admin_scripts/README_cache_management.md
+++ b/admin_scripts/README_cache_management.md
@@ -1,0 +1,104 @@
+# Redis Cache Management
+
+This document explains how to manage the Redis cache for the crashed-backend application.
+
+## Quick Start
+
+The `clear_redis_cache.py` script provides several commands to manage the Redis cache:
+
+### 1. Clear All Cache (Recommended)
+
+This is the safest way to clear the cache. It updates the cache version, invalidating all existing cached data:
+
+```bash
+python admin_scripts/clear_redis_cache.py clear --all
+```
+
+### 2. Clear Specific Cache Patterns
+
+To clear only specific types of cached data:
+
+```bash
+# Clear all analytics cache
+python admin_scripts/clear_redis_cache.py clear --pattern "analytics:*"
+
+# Clear all games list cache
+python admin_scripts/clear_redis_cache.py clear --pattern "games:*"
+
+# Clear all individual game detail cache
+python admin_scripts/clear_redis_cache.py clear --pattern "game:*"
+```
+
+### 3. View Cache Statistics
+
+To see current cache usage and statistics:
+
+```bash
+python admin_scripts/clear_redis_cache.py stats
+```
+
+### 4. List Cache Keys
+
+To see what's currently cached:
+
+```bash
+# List all keys
+python admin_scripts/clear_redis_cache.py list
+
+# List specific pattern
+python admin_scripts/clear_redis_cache.py list --pattern "analytics:*"
+```
+
+### 5. Flush Entire Database (WARNING)
+
+This deletes ALL data in Redis, not just cache. Use with extreme caution:
+
+```bash
+python admin_scripts/clear_redis_cache.py flush
+```
+
+## Cache Key Patterns
+
+The application uses the following cache key patterns:
+
+- `analytics:*` - Analytics endpoint cache (intervals, occurrences, series, etc.)
+- `games:*` - Games list endpoint cache
+- `game:*` - Individual game detail cache
+
+All keys include a version suffix (e.g., `:v1`) that changes when cache is invalidated.
+
+## Alternative Method: Using Redis CLI
+
+If you have direct access to Redis CLI:
+
+```bash
+# Connect to Redis
+redis-cli
+
+# List all keys
+KEYS *
+
+# Delete specific pattern
+DEL analytics:*
+
+# Flush database (WARNING: deletes everything)
+FLUSHDB
+```
+
+## When to Clear Cache
+
+You should clear the cache when:
+
+1. You've made code changes that affect the data structure or calculation logic
+2. You've manually updated data in the database
+3. You're debugging and need to see fresh results
+4. The cached data seems stale or incorrect
+
+## Cache TTL (Time-To-Live)
+
+The application automatically expires cache entries based on configured TTL values:
+
+- Short TTL (default 300s / 5 minutes): For frequently changing data
+- Long TTL (default 3600s / 1 hour): For stable data
+
+Cache entries will automatically expire after their TTL, so manual clearing is only needed for immediate updates.

--- a/admin_scripts/clear_redis_cache.py
+++ b/admin_scripts/clear_redis_cache.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Redis Cache Management Tool for Crash Monitor.
+
+This script provides utilities to manage the Redis cache for the crashed-backend application.
+"""
+
+import argparse
+import sys
+import os
+import time
+from urllib.parse import urlparse
+
+# Add the src directory to Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from src import config
+from src.utils.redis import get_redis_client, is_redis_available, setup_redis
+from src.utils.redis_keys import set_cache_version, invalidate_specific_analytics_cache
+
+
+def clear_all_cache():
+    """Clear all cache entries by updating the cache version."""
+    print("Clearing all cache by updating cache version...")
+    old_version = set_cache_version()
+    print(f"Cache version updated. All cached data with version {old_version} is now invalid.")
+    print("New cache entries will be created as requests come in.")
+
+
+def clear_specific_pattern(pattern):
+    """Clear cache entries matching a specific pattern."""
+    print(f"Clearing cache entries matching pattern: {pattern}")
+    count = invalidate_specific_analytics_cache(pattern)
+    print(f"Deleted {count} cache entries.")
+
+
+def flush_all_redis():
+    """Flush the entire Redis database (WARNING: This deletes ALL data)."""
+    print("WARNING: This will delete ALL data in Redis, not just cache!")
+    confirm = input("Are you sure you want to flush the entire Redis database? (yes/no): ")
+    
+    if confirm.lower() != 'yes':
+        print("Operation cancelled.")
+        return
+    
+    try:
+        redis = get_redis_client()
+        redis.flushdb()
+        print("Redis database flushed successfully.")
+    except Exception as e:
+        print(f"Error flushing Redis: {str(e)}")
+
+
+def list_cache_keys(pattern="*"):
+    """List all cache keys matching a pattern."""
+    try:
+        redis = get_redis_client()
+        keys = redis.keys(pattern)
+        
+        if not keys:
+            print(f"No keys found matching pattern: {pattern}")
+            return
+        
+        print(f"Found {len(keys)} keys matching pattern: {pattern}")
+        print("-" * 60)
+        
+        for key in sorted(keys):
+            # Decode key if it's bytes
+            if isinstance(key, bytes):
+                key = key.decode('utf-8')
+            
+            # Get TTL
+            ttl = redis.ttl(key)
+            ttl_str = f"{ttl}s" if ttl > 0 else "no expiry" if ttl == -1 else "expired"
+            
+            print(f"{key:<50} TTL: {ttl_str}")
+            
+    except Exception as e:
+        print(f"Error listing keys: {str(e)}")
+
+
+def show_cache_stats():
+    """Show Redis cache statistics."""
+    try:
+        redis = get_redis_client()
+        info = redis.info()
+        
+        print("Redis Cache Statistics")
+        print("=" * 60)
+        
+        # Memory stats
+        print(f"Used Memory: {info.get('used_memory_human', 'N/A')}")
+        print(f"Peak Memory: {info.get('used_memory_peak_human', 'N/A')}")
+        print(f"Memory Fragmentation Ratio: {info.get('mem_fragmentation_ratio', 'N/A')}")
+        
+        # Key stats
+        all_keys = redis.keys("*")
+        analytics_keys = redis.keys("analytics:*")
+        games_keys = redis.keys("games:*")
+        game_keys = redis.keys("game:*")
+        
+        print(f"\nTotal Keys: {len(all_keys)}")
+        print(f"Analytics Keys: {len(analytics_keys)}")
+        print(f"Games List Keys: {len(games_keys)}")
+        print(f"Game Detail Keys: {len(game_keys)}")
+        
+        # Connection stats
+        print(f"\nConnected Clients: {info.get('connected_clients', 'N/A')}")
+        print(f"Total Commands Processed: {info.get('total_commands_processed', 'N/A')}")
+        
+        # Persistence stats
+        print(f"\nLast Save Time: {time.ctime(info.get('rdb_last_save_time', 0))}")
+        print(f"AOF Enabled: {'yes' if info.get('aof_enabled', 0) == 1 else 'no'}")
+        
+    except Exception as e:
+        print(f"Error getting cache stats: {str(e)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Redis Cache Management Tool")
+    
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+    
+    # Clear all cache
+    clear_parser = subparsers.add_parser("clear", help="Clear cache entries")
+    clear_parser.add_argument(
+        "--pattern",
+        help="Clear only keys matching this pattern (e.g., 'analytics:*')"
+    )
+    clear_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Clear all cache by updating cache version"
+    )
+    
+    # Flush database
+    flush_parser = subparsers.add_parser(
+        "flush",
+        help="Flush entire Redis database (WARNING: deletes ALL data)"
+    )
+    
+    # List keys
+    list_parser = subparsers.add_parser("list", help="List cache keys")
+    list_parser.add_argument(
+        "--pattern",
+        default="*",
+        help="Pattern to match keys (default: '*')"
+    )
+    
+    # Show stats
+    stats_parser = subparsers.add_parser("stats", help="Show cache statistics")
+    
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return
+    
+    # Setup Redis connection
+    try:
+        setup_redis()
+        
+        if not is_redis_available():
+            print("Error: Redis is not available. Please check your Redis connection.")
+            sys.exit(1)
+            
+    except Exception as e:
+        print(f"Error connecting to Redis: {str(e)}")
+        sys.exit(1)
+    
+    # Execute command
+    if args.command == "clear":
+        if args.all:
+            clear_all_cache()
+        elif args.pattern:
+            clear_specific_pattern(args.pattern)
+        else:
+            print("Please specify --all or --pattern")
+            
+    elif args.command == "flush":
+        flush_all_redis()
+        
+    elif args.command == "list":
+        list_cache_keys(args.pattern)
+        
+    elif args.command == "stats":
+        show_cache_stats()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Fixed an issue where the oldest series in the analytics results would always have length 1
- Added Redis cache management tools for easier debugging and maintenance

## Bug Fix Details
The problem occurred when the oldest game in the analyzed window had a crash point >= min_value. The algorithm incorrectly assumed this was a standalone series without checking if it was terminating a previous series.

## Changes
1. **Series Analytics Fix**:
   - Updated `_extend_games_for_complete_streaks` to always check backwards when the oldest game has a high crash point
   - Modified series processing logic to avoid creating length-1 series for the first game in the window
   - Added logic to determine if a high crash point game at the boundary is truly standalone or terminating a series

2. **Cache Management Tools**:
   - Added `admin_scripts/clear_redis_cache.py` - comprehensive cache management script
   - Added `admin_scripts/README_cache_management.md` - documentation for cache operations
   - Supports clearing all cache, pattern-based clearing, viewing stats, and listing keys

## Test plan
- [x] Tested with `/api/analytics/series/without-min-crash-point/11?limit=100` - no more spurious length-1 series
- [x] Tested with larger limits (1000 games) to ensure edge cases are handled correctly
- [x] Verified that legitimate length-1 series (standalone high crashes in the middle of data) are still captured
- [x] Tested cache management script - all commands work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)